### PR TITLE
fix/replica_manager: register transfer at sender

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,7 +2032,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 [[package]]
 name = "safe-nd"
 version = "0.10.0"
-source = "git+https://github.com/maidsafe/safe-nd?branch=at2#3dd4f36945516399a7c4906ff8e1a3210f717f35"
+source = "git+https://github.com/maidsafe/safe-nd?branch=at2#d58a9e3786635fb55f0db17e824a85342e4b02d6"
 dependencies = [
  "bincode",
  "crdts",

--- a/src/client_handler/replica_manager.rs
+++ b/src/client_handler/replica_manager.rs
@@ -202,7 +202,7 @@ impl EventStore {
                 self.group_changes.push(e);
             }
             ReplicaEvent::TransferPropagated(e) => {
-                let id = e.debit_proof.signed_transfer.transfer.to;
+                let id = e.to();
                 match self.streams.get_mut(&id) {
                     Some(stream) => stream.push(event),
                     None => {
@@ -212,14 +212,14 @@ impl EventStore {
                 }
             }
             ReplicaEvent::TransferValidated(e) => {
-                let id = e.signed_transfer.transfer.id.actor;
+                let id = e.from();
                 match self.streams.get_mut(&id) {
                     Some(stream) => stream.push(event),
                     None => return Err(Error::InvalidOperation), // A stream cannot start with a debit.
                 }
             }
             ReplicaEvent::TransferRegistered(e) => {
-                let id = e.debit_proof.signed_transfer.transfer.to;
+                let id = e.from();
                 match self.streams.get_mut(&id) {
                     Some(stream) => stream.push(event),
                     None => return Err(Error::InvalidOperation), // A stream cannot start with a debit.


### PR DESCRIPTION
- TransferRegistered is to be pushed to the stream of the sender,
not the recipient.
- Also uses the simplified api of the event.